### PR TITLE
Local Host Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 Simple application to review compliance against NTCIP 1218 standard. Note this is the initial version and will be updated with more features in the future. Currently only a subset of MIBs are checked. 
 
-The [ntcip1218_compliance_check.py](./ntcip1218_compliance_check.py) script executes a series of SNMP commands to an RSU. Command host must a server with an SNMP service configured and running. If MIB names are used in the input commands then the appropriate MIB files must be configured on the host server.
+The [ntcip1218_compliance_check.py](./ntcip1218_compliance_check.py) script executes a series of SNMP commands to an RSU. Command host must a server with an SNMP service configured and running, either locally or remotely. If MIB names are used in the input commands then the appropriate MIB files must be configured on the host server.
 
 
 ### Prerequisites
 Python 3.12 or higher is required to run this project. Virtual environment is recommended to keep the dependencies clean and isolated from other projects.
 
-A JSON file is used to store the SNMP commands to be executed, see [sample_snmp.json](./sample_snmp.json) for an example. Note that two sets of credentials are required to run the script, one for SSH and one for SNMP. The SSH credentials are used to connect to the host server and the SNMP credentials are used to execute the SNMP commands. SSH credentials are stored in the JSON file under the key "snmp_host" and SNMP credentials are stored under the key "snmp_connection".
+A JSON file is used to store the SNMP commands to be executed, see [sample_snmp.json](./sample_snmp.json) for an example. Note that two sets of credentials are required to run the script on a remote host, one for SSH and one for SNMP. SNMP credentials are only required if running on a local host. The SSH credentials are used to connect to the host server and the SNMP credentials are used to execute the SNMP commands. SSH credentials are stored in the JSON file under the key "snmp_host" and SNMP credentials are stored under the key "snmp_connection". To specify if the script is intended to run on a local host, set the "host_type" field's value to "local", otherwise leave as "remote".
 
 ## Usage <a name = "usage"></a>
 

--- a/ntcip1218_compliance_check.py
+++ b/ntcip1218_compliance_check.py
@@ -1,7 +1,7 @@
 import argparse
 import csv
 import json
-#import paramiko
+import paramiko
 import re
 import subprocess
 

--- a/sample_snmp.json
+++ b/sample_snmp.json
@@ -1,5 +1,6 @@
 {
     "snmp_host": {
+        "host_type": "remote",
         "host_reference": "1.1.1.1",
         "host_user": "someuser",
         "host_pw":"somepw"


### PR DESCRIPTION
This pull request adds local host support using the Python library `subprocess`. This can be customized through the `sample_snmp.json`.

I found this necessary for my situation since I didn't have a convenient remote Linux server with Python 3.12. I added this support while waiting for the Python 3.12 tarball to be built and installed on the CDOT VM so I could just do it from my machine's WSL.