### PR TITLE
Hostcommand  update SNMP host server and updated command response evaluation for multiple responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 - [About](#about)
-- [Getting Started](#getting_started)
+- [Getting Started](#getting-started)
 - [Usage](#usage)
 - [Contributing](../CONTRIBUTING.md)
 
@@ -11,13 +11,29 @@
 
 Simple application to review compliance against NTCIP 1218 standard. Note this is the initial version and will be updated with more features in the future. Currently only a subset of MIBs are checked. 
 
-The [ntcip1218_compliance_check.py](./ntcip1218_compliance_check.py) script executes a series of SNMP commands to an RSU. Command host must a server with an SNMP service configured and running, either locally or remotely. If MIB names are used in the input commands then the appropriate MIB files must be configured on the host server.
+The [ntcip1218_compliance_check.py](./ntcip1218_compliance_check.py) script executes a series of SNMP commands to an RSU. Command host must be a server with an SNMP service configured and running, either locally or remotely. If MIB names are used in the input commands then the appropriate MIB files must be configured on the host server.
 
 
 ### Prerequisites
-Python 3.12 or higher is required to run this project. Virtual environment is recommended to keep the dependencies clean and isolated from other projects.
+Python 3.12 or higher is required to run this project. Virtual environment is recommended to keep the dependencies clean and isolated from other projects.  
 
-A JSON file is used to store the SNMP commands to be executed, see [sample_snmp.json](./sample_snmp.json) for an example. Note that two sets of credentials are required to run the script on a remote host, one for SSH and one for SNMP. SNMP credentials are only required if running on a local host. The SSH credentials are used to connect to the host server and the SNMP credentials are used to execute the SNMP commands. SSH credentials are stored in the JSON file under the key "snmp_host" and SNMP credentials are stored under the key "snmp_connection". To specify if the script is intended to run on a local host, set the "host_type" field's value to "local", otherwise leave as "remote".
+The host server executing the SNMP commands must have an SNMP service configured and running. If MIB names are used in the SNMP commands, then the host SNMP service must be configured with the appropriate MIB files.
+
+If the host server is remote (i.e. not the server running the script) then appropriate login information must be configured in the SNMP command file to support an SSH login to the remote host. 
+
+## Getting Started <a name = "getting-started"></a>
+
+A JSON file is used to store the SNMP commands to be executed, see [sample_read_snmp.json](./sample_read_snmp.json) for an example. Note that the script can be run directly on the host that executes the SNMP commands or the script can be run on a different server and connect to the remote host that executes the SNMP commands. These different run configurations are specified in the "snmp_host.host_type" element of the SNMP command file. There are three configuration values supported:
+- "remote-key"   
+    Connect to a remote host using a private key file for ssh login authentication. The "host_private_key" element contains the path to the private_key file. If the private_key file requires a pass phrase, then this pass phrase must be specified in the "host_pw" element.  
+
+- "remote-pw"  
+    Connect to a remote host using a password for ssh login authentication. The "host_pw" element must contain the password for ssh login to the remote host.  
+
+- "local"  
+    The host executing the SNMP commands is the server that the script is running on. SNMP commands are executed directly as shell commands from the script. For this local configuration, the other "snmp_host" elements are not required.  
+
+The snmp_connection element holds data required to execute an SNMP command to the target RSU. The device_reference element contains the an ip address or URL to reach the target RSU, the security element contains the preliminary portion of the SNMP command string including the SNMP user name, authentication protocol and password, and encryption protocol and password.
 
 ## Usage <a name = "usage"></a>
 

--- a/ntcip1218_compliance_check.py
+++ b/ntcip1218_compliance_check.py
@@ -59,16 +59,16 @@ def remote_host_execute(hostdata, cmd):
 
         # connect with password
         if hostdata["host_type"] == "remote_pw":
-            client.connect(hostname=hostdata["host"], 
-                   username=hostdata["user"], 
-                   password=hostdata["pw"])
+            client.connect(hostname=hostdata["host_reference"], 
+                   username=hostdata["host_user"], 
+                   password=hostdata["host_pw"])
 
         # connect with private key 
         # password is used as the private key passphrase 
         else:
-            client.connect(hostname=hostdata["host"], 
-                   username=hostdata["user"], 
-                   password=hostdata["pw"],
+            client.connect(hostname=hostdata["host_reference"], 
+                   username=hostdata["host_user"], 
+                   password=hostdata["host_pw"],
                    key_filename=hostdata["host_private_key"])
             
         # Execute the SNMP command 
@@ -83,8 +83,8 @@ def remote_host_execute(hostdata, cmd):
             "Failed to authenticate on remote host with the following data "
             "host_type: {}  host: {}  user: {}  password: {} "
             "private key path: {}")
-        errorMsg = errorMsg.format(hostdata["host_type"], hostdata["host"],
-                                   hostdata["user"], hostdata["pw"],
+        errorMsg = errorMsg.format(hostdata["host_type"], hostdata["host_reference"],
+                                   hostdata["host_user"], hostdata["host_pw"],
                                    hostdata["host_private_key"])
         raise ValueError(errorMsg)
                     

--- a/ntcip1218_compliance_check.py
+++ b/ntcip1218_compliance_check.py
@@ -5,6 +5,95 @@ import paramiko
 import re
 import subprocess
 
+
+def local_host_execute(cmd):
+    """
+    This function executes the given SNMP command on a local host 
+    (the server that this script is running on). The stdout and stderr 
+    strings are returned from the execution of the SNMP command.
+
+    Parameters:
+        cmd (string): the assembled SNMP command to execute
+        snmpdata (dict): security string and device ip for snmp command
+        cmddata (dict): reference name, command elements and evaluation strings
+
+    Returns:
+        str: stdout text from the command execution
+        str: stderr text from the command execution
+    """
+    # Execute SNMP command
+    cmdresult = ""
+    cmderror = ""
+    try:
+        result = subprocess.run(cmd, shell=True, capture_output=True, check=True)
+        cmdresult = result.stdout.decode()
+        print("stdout: {}".format(cmdresult))
+    except subprocess.CalledProcessError as e:
+        cmderror = e.stderr.decode()
+        print("SNMP command failed: {}".format(cmderror))
+
+    return cmdresult, cmderror
+
+def remote_host_execute(hostdata, cmd):
+    """
+    This function executes the given SNMP command on a remote host. 
+    The remote host may authenticate a shell access using either a 
+    password or private key. The remote shell access is implemented 
+    using paramiko.  
+
+    Parameters:
+        hostdata (dict): access data for the remote host executing the snmp command
+        cmd (string): the fully defined SNMP command to execute on the remote host
+
+    Returns:
+        str: stdout text from the command execution
+        str: stderr text from the command execution
+    """
+    # open parimiko shell to SNMP host
+    # Create ssh client
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    # Connect to the remote host and execute the SNMP command
+    try:
+
+        # connect with password
+        if hostdata["host_type"] == "remote_pw":
+            client.connect(hostname=hostdata["host"], 
+                   username=hostdata["user"], 
+                   password=hostdata["pw"])
+
+        # connect with private key 
+        # password is used as the private key passphrase 
+        else:
+            client.connect(hostname=hostdata["host"], 
+                   username=hostdata["user"], 
+                   password=hostdata["pw"],
+                   key_filename=hostdata["host_private_key"])
+            
+        # Execute the SNMP command 
+        stdin, stdout, stderr = client.exec_command(cmd)
+        cmdresult = stdout.read().decode()
+        cmderror = stderr.read().decode()
+        print("stdout: {}".format(cmdresult))
+        print("stderr: {}".format(cmderror))
+            
+    except paramiko.AuthenticationException as e:
+        errorMsg = (
+            "Failed to authenticate on remote host with the following data "
+            "host_type: {}  host: {}  user: {}  password: {} "
+            "private key path: {}")
+        errorMsg = errorMsg.format(hostdata["host_type"], hostdata["host"],
+                                   hostdata["user"], hostdata["pw"],
+                                   hostdata["host_private_key"])
+        raise ValueError(errorMsg)
+                    
+    finally:
+        client.close()
+    
+    # return the raw stdout and stderr strings from the command execution
+    return cmdresult, cmderror
+
 def evaluate_result(result_string, cmddata):
     """
     This function evaluates the data returned from the SNMP command and 
@@ -17,7 +106,7 @@ def evaluate_result(result_string, cmddata):
     match using simple RE. 
 
     Parameters:
-        result_sting (string): concatenated standard output and standard err from command
+        result_string (string): concatenated standard output and standard err from command
         cmddata (dict): contains reference name, command elements and evaluation strings
 
     Returns:
@@ -50,15 +139,16 @@ def evaluate_result(result_string, cmddata):
 def execute_snmp_command(hostdata, snmpdata, cmddata):
     """
     This function executes the given SNMP command and evaluates the result.
-    The SNMP command is executed on a remote host using a paramiko shell 
-    command execution. The result of the SNMP command is evaluated to check
-    if the command succeeded or failed. Results including a pass/fail flag
-    are returned from this routine. 
+    The SNMP command is executed on the host defined in the hostdata. The host 
+    may be remote (remote ssh access) or local (direct shell access). The 
+    result of the SNMP command is evaluated to check if the command succeeded 
+    or failed. Results of the executed snmp command are returned along with
+    a pass/fail flag.
 
     Parameters:
-        hostdata (dict): contains login data for remote host 
-        snmpdata (dict): contains security string and device ip for snmp command
-        cmddata (dict): contains reference name, command elements and evaluation strings
+        hostdata (dict): access data for the host executing the snmp command
+        snmpdata (dict): security string and device ip for snmp command
+        cmddata (dict): reference name, command elements and evaluation strings
 
     Returns:
         str: reference information for the command
@@ -75,71 +165,20 @@ def execute_snmp_command(hostdata, snmpdata, cmddata):
     for cmd_element in cmddata["command"]["snmp_cmd_elements"]:
         cmd =  cmd + " " + cmd_element
 
-    # open parimiko shell to SNMP host
-    # Create ssh client
-    client = paramiko.SSHClient()
-    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    # determine the host type to execute the SNMP command
+    # "remote_key"  remote host using a private key for ssh login authentication
+    # "remote_pw"   remote host using a password for ssh login authentication
+    # "local"       local host using direct shell commands (no shell login required)
+    # this statement is here primarily to confirm the host_type is specified correctly
+    match hostdata['host_type']:
+        case "remote_pw" | "remote_key":
+            cmdresult, cmderror = remote_host_execute(hostdata,cmd)
 
-    # Connect to the remote host
-    client.connect(hostdata["host"], 
-                   username=hostdata["user"], 
-                   password=hostdata["pw"])
+        case "local":
+            cmdresult, cmderror = local_host_execute(cmd)
 
-    # Execute command
-    stdin, stdout, stderr = client.exec_command(cmd)
-    cmdresult = stdout.read().decode()
-    cmderror = stderr.read().decode()
-    print("stdout: {}".format(cmdresult))
-    print("stderr: {}".format(cmderror))
-
-    # Close connection
-    client.close()
-
-    # Evaluate the result from the command execution
-    # The stdout and stderr strings often contain newlines, which complicates
-    #  analysis, so these strings are flattened and concatenated
-    cmdresult = cmdresult.replace("\n", " ") + cmderror.replace("\n", " ")
-    result_evaluation = evaluate_result(cmdresult, cmddata)
-
-    return result_evaluation, cmdresult
-
-def execute_snmp_command_local(snmpdata, cmddata):
-    """
-    This function executes the given SNMP command and evaluates the result.
-    The SNMP command is executed on the local host using the shell. 
-    The result of the SNMP command is evaluated to check
-    if the command succeeded or failed. Results including a pass/fail flag
-    are returned from this routine. 
-
-    Parameters:
-        snmpdata (dict): contains security string and device ip for snmp command
-        cmddata (dict): contains reference name, command elements and evaluation strings
-
-    Returns:
-        str: reference information for the command
-        str: output text from the command execution no truncation.
-        str: result evaluation 'pass'|'fail'|'unknown'
-    """
-    # build snmp command (verb, security, device_reference)
-    snmp_verb = cmddata["command"]["snmp_cmd"]
-    snmp_security = snmpdata["snmp_security"]
-    snmp_device = snmpdata["snmp_device"]
-    cmd = f"{snmp_verb} {snmp_security} {snmp_device}"
-
-    # add multiple command elements to the command
-    for cmd_element in cmddata["command"]["snmp_cmd_elements"]:
-        cmd =  cmd + " " + cmd_element
-
-    # Execute command
-    cmdresult = ""
-    cmderror = ""
-    try:
-        result = subprocess.run(cmd, shell=True, capture_output=True, check=True)
-        cmdresult = result.stdout.decode()
-        print("stdout: {}".format(cmdresult))
-    except subprocess.CalledProcessError as e:
-        cmderror = e.stderr.decode()
-        print(f"Command not supported: {e}")
+        case _:
+            raise ValueError("Unknown host type. Host type must be one of: 'remote_pw', 'remote_key', 'local'")
 
     # Evaluate the result from the command execution
     # The stdout and stderr strings often contain newlines, which complicates
@@ -164,14 +203,12 @@ def run_test_commands(cmdfilepath, outfilepath, truncatelength):
     with open(cmdfilepath, 'r') as cmdfile:
         cmddata = json.load(cmdfile)
 
-    # assemble host shell login elements {host, user, pw}
-    remote_host = True if cmddata['snmp_host']['host_type'] == "remote" else False
-
-    if remote_host:
-        host_login = {"host": cmddata['snmp_host']['host_reference'], 
-                "user": cmddata['snmp_host']['host_user'],
-                "pw": cmddata['snmp_host']['host_pw'] }
-        print(host_login)
+    # assemble host shell login elements {host_type, host_reference, user, pw}
+    # determine the type of host access and specify the host command execute function
+    
+    # collect the host data {host_type, host_reference, host_user, host_pw, host_private_key}
+    # this host data defines the connection to the host that executes the snmp command
+    host_data = cmddata['snmp_host']
 
     # assemble default snmp command string elements (snmp security, snmp device)
     snmp_elements = {"snmp_security": cmddata['snmp_connection']['security'],
@@ -188,11 +225,8 @@ def run_test_commands(cmdfilepath, outfilepath, truncatelength):
         cmd_type = cmd["command"]["snmp_cmd"]
         print("testing cmd: {}".format(cmd_reference))
 
-        # execute test command based on remote or local host
-        if remote_host:
-            cmdresult, resultdata = execute_snmp_command(host_login, snmp_elements, cmd)
-        else:
-            cmdresult, resultdata = execute_snmp_command_local(snmp_elements, cmd)
+        # execute test command based on host
+        cmdresult, resultdata = execute_snmp_command(host_data, snmp_elements, cmd)
 
         # truncate the result string to user specified length
         # truncated for output only, evaluation occurred with the full output string 

--- a/ntcip1218_compliance_check.py
+++ b/ntcip1218_compliance_check.py
@@ -177,27 +177,25 @@ def execute_snmp_command(host_exec_func, hostdata, snmpdata, cmddata):
 
 def run_test_commands(cmdfilepath, outfilepath, truncatelength):
     """
-    This function organizes a series of test snmp commands then 
+    This function reads in a series of test snmp commands then 
     executes each test command and records the result of each 
     command to the specified output file. 
 
     Parameters:
-        cmdfilepath (file path): input file containing all the snmp commands to test
+        cmdfilepath (file path): input file containing the series of snmp commands to test
         outfilepath (file path): file to record results of the test
-        truncatelength (integer): max written length of the command output string
+        truncatelength (integer): max written length of the command results output string
     """
     # Read the SNMP command file - create corresponding cmddata dictionary
     with open(cmdfilepath, 'r') as cmdfile:
         cmddata = json.load(cmdfile)
 
-    # assemble host shell login elements {host_type, host_reference, user, pw}
-    # determine the type of host access and specify the host command execute function
-    
     # collect the host data {host_type, host_reference, host_user, host_pw, host_private_key}
     # this host data defines the connection to the host that executes the snmp command
     host_data = cmddata['snmp_host']
 
-    # determine the host function to execute the SNMP command
+    # determine the type of host access 
+    # specify the host function to execute the SNMP command
     # "remote_key"  remote host using a private key for ssh login authentication
     # "remote_pw"   remote host using a password for ssh login authentication
     # "local"       local host using direct shell commands (no shell login required)
@@ -205,15 +203,12 @@ def run_test_commands(cmdfilepath, outfilepath, truncatelength):
     match host_data['host_type']:
         case "remote_pw" | "remote_key":
             exec_function = remote_host_execute
-            #cmdresult, cmderror = remote_host_execute(hostdata,cmd)
 
         case "local":
             exec_function = local_host_execute
-            #cmdresult, cmderror = local_host_execute(cmd)
 
         case _:
             raise ValueError("Unknown host type. Host type must be one of: 'remote_pw', 'remote_key', 'local'")
-
 
     # assemble default snmp command string elements (snmp security, snmp device)
     snmp_elements = {"snmp_security": cmddata['snmp_connection']['security'],

--- a/sample_read_snmp.json
+++ b/sample_read_snmp.json
@@ -1,9 +1,10 @@
 {
     "snmp_host": {
-        "host_type": "remote",
+        "host_type": "remote_pw",
         "host_reference": "1.1.1.1",
         "host_user": "someuser",
-        "host_pw":"somepw"
+        "host_pw":"somepw",
+        "host_private_key":"/path/to/key.pem"
     },
     "snmp_connection": {
         "security": "-v 3 -u <snmpuser> -a SHA -A <authpw> -x AES -X <encryptpw> -l authpriv",

--- a/sample_read_snmp.json
+++ b/sample_read_snmp.json
@@ -19,7 +19,7 @@
                     "NTCIP1218-v01::rsuModeStatus.0"
                 ],
                 "success_return": ["INTEGER: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -30,7 +30,7 @@
                     "NTCIP1218-v01::rsuGnssStatus.0"
                 ],
                 "success_return": ["INTEGER: [1-9]"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -41,7 +41,7 @@
                     "NTCIP1218-v01::rsuGnssAugmentation.0"
                 ],
                 "success_return": ["INTEGER: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -51,7 +51,7 @@
                 "snmp_cmd_elements": [
                     "NTCIP1218-v01::rsuGnssOutputString.0"
                 ],
-                "success_return": [],
+                "success_return": ["$GPGGA,[0-9]+"],
                 "fail_return": ["error", "GPGGA,{4}"]
             }
         },
@@ -85,7 +85,7 @@
                     "NTCIP1218-v01::rsuGnssElv.0"
                 ],
                 "success_return": ["-?[0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -96,7 +96,7 @@
                     "NTCIP1218-v01::rsuLocationLat.0"
                 ],
                 "success_return": ["INTEGER: -?[0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -107,7 +107,7 @@
                     "NTCIP1218-v01::rsuLocationLon.0"
                 ],
                 "success_return": ["INTEGER: -?[0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -129,7 +129,7 @@
                     "NTCIP1218-v01::rsuLocationDesc.0"
                 ],
                 "success_return": ["STRING: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -140,7 +140,7 @@
                     "NTCIP1218-v01::rsuGnssMaxDeviation.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -151,7 +151,7 @@
                     "NTCIP1218-v01::rsuLocationDeviation.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+","20001"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -162,7 +162,7 @@
                     "NTCIP1218-v01::rsuGnssPositionError.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+","200001"],
-                "fail_return": ["no such instance"]
+                "fail_return": ["no such instance", "no such object"]
             }
         },
         {
@@ -173,7 +173,7 @@
                     "NTCIP1218-v01::rsuStatus.0"
                 ],
                 "success_return": ["INTEGER: [1-5]", "okay", "warning", "critical", "unknown"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -184,7 +184,7 @@
                     "NTCIP1218-v01::rsuFirmwareVersion.0"
                 ],
                 "success_return": ["STRING: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -195,7 +195,7 @@
                     "NTCIP1218-v01::rsuMibVersion.0"
                 ],
                 "success_return": ["STRING: NTCIP1218"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -206,7 +206,7 @@
                     "NTCIP1218-v01::rsuID.0"
                 ],
                 "success_return": ["STRING: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -217,7 +217,7 @@
                     "NTCIP1218-v01::rsuHostIpAddr.0"
                 ],
                 "success_return": ["STRING: [0-9A-Fa-f]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -228,7 +228,7 @@
                     "NTCIP1218-v01::rsuHostNetMask.0"
                 ],
                 "success_return": ["STRING: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -239,7 +239,7 @@
                     "NTCIP1218-v01::rsuHostGateway.0"
                 ],
                 "success_return": ["STRING: [0-9A-Fa-f]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -250,7 +250,7 @@
                     "NTCIP1218-v01::rsuHostDNS.0"
                 ],
                 "success_return": ["STRING: [0-9A-Fa-f]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -261,7 +261,7 @@
                     "NTCIP1218-v01::rsuHostDHCPEnable.0"
                 ],
                 "success_return": ["STRING: [1-2]+", "disable", "enable"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
 
@@ -273,7 +273,7 @@
                     "NTCIP1218-v01::rsuServiceTable"
                 ],
                 "success_return": ["STRING: RSU","STRING: GNSS"],
-                "fail_return": ["no such instance"]
+                "fail_return": ["no such instance", "no such object"]
             }
         },
         {
@@ -284,7 +284,7 @@
                     "NTCIP1218-v01::rsuReboot.0"
                 ],
                 "success_return": ["INTEGER: 0"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -295,7 +295,7 @@
                     "NTCIP1218-v01::rsuTimeSincePowerOn.0"
                 ],
                 "success_return": ["Counter32: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -306,7 +306,7 @@
                     "NTCIP1218-v01::rsuIntTemp.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -317,7 +317,7 @@
                     "NTCIP1218-v01::maxRsuMessageCountsByPsid.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -328,7 +328,7 @@
                     "NTCIP1218-v01::rsuMessageCountsByPsidTable"
                 ],
                 "success_return": [],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error"]
             }
         },
         {
@@ -339,7 +339,7 @@
                     "NTCIP1218-v01::rsuClockSource.0"
                 ],
                 "success_return": ["INTEGER: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -350,7 +350,7 @@
                     "NTCIP1218-v01::rsuClockSourceStatus.0"
                 ],
                 "success_return": ["INTEGER: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -361,7 +361,7 @@
                     "NTCIP1218-v01::rsuClockSourceTimeout.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -372,7 +372,7 @@
                     "NTCIP1218-v01::rsuClockDeviationTolerance.0 i 0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -383,7 +383,7 @@
                     "NTCIP1218-v01::maxRsuReceivedMsgs.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -393,8 +393,8 @@
                 "snmp_cmd_elements": [
                     "NTCIP1218-v01::rsuReceivedMsgTable"
                 ],
-                "success_return": [],
-                "fail_return": ["error", "no such instance"]
+                "success_return": ["STRING: [0-9]+"],
+                "fail_return": ["error"]
             }
         },
         {
@@ -405,7 +405,7 @@
                     "NTCIP1218-v01::maxRsuMsgRepeat.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -425,7 +425,7 @@
                     "rsuMsgRepeatOptions.55 x 00"
                 ],
                 "success_return": ["55 = INTEGER: 183"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -436,7 +436,7 @@
                     "NTCIP1218-v01::rsuMsgRepeatStatusTable"
                 ],
                 "success_return": ["55 = INTEGER: 183"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -447,7 +447,7 @@
                     "NTCIP1218-v01::rsuMsgRepeatOptions.55"
                 ],
                 "success_return": ["BITS: [01]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -458,7 +458,7 @@
                     "NTCIP1218-v01::rsuMsgRepeatStatus.55 i 6"
                 ],
                 "success_return": ["55 = INTEGER: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -469,7 +469,7 @@
                     "NTCIP1218-v01::rsuSecCredReq.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -480,7 +480,7 @@
                     "NTCIP1218-v01::rsuSecEnrollCertStatus.0"
                 ],
                 "success_return": ["INTEGER: ", "enrolled", "notEnrolled", "unknown"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -491,7 +491,7 @@
                     "NTCIP1218-v01::rsuSecEnrollCertValidRegion.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -502,7 +502,7 @@
                     "NTCIP1218-v01::rsuSecEnrollCertUrl.0"
                 ],
                 "success_return": ["STRING: https"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -513,7 +513,7 @@
                     "NTCIP1218-v01::rsuSecEnrollCertId.0"
                 ],
                 "success_return": ["STRING: "],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -524,7 +524,7 @@
                     "NTCIP1218-v01::rsuSecEnrollCertExpiration.0"
                 ],
                 "success_return": ["STRING: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -535,7 +535,7 @@
                     "NTCIP1218-v01::rsuSecuritySource.0"
                 ],
                 "success_return": ["INTEGER: ", "scms"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -546,7 +546,7 @@
                     "NTCIP1218-v01::rsuSecAppCertUrl.0"
                 ],
                 "success_return": ["STRING: https"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -557,7 +557,7 @@
                     "NTCIP1218-v01::maxRsuSecAppCerts.0"
                 ],
                 "success_return": ["INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -568,7 +568,7 @@
                     "NTCIP1218-v01::rsuSecAppCertTable"
                 ],
                 "success_return": ["1 = INTEGER: [0-9]+"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -579,7 +579,7 @@
                     "NTCIP1218-v01::rsuSecCertRevocationUrl.0"
                 ],
                 "success_return": ["STRING: https"],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         },
         {
@@ -590,7 +590,7 @@
                     "NTCIP1218-v01::rsuSecCertRevocationTime.0"
                 ],
                 "success_return": [],
-                "fail_return": ["error", "no such instance"]
+                "fail_return": ["error", "no such instance", "no such object"]
             }
         }
     ]


### PR DESCRIPTION
Updated primary script to allow multiple remote snmp host types:   remote-pw, remote-key, and local. Updated the remote vs local access to simplify the processing flow. Updated the command JSON file to correctly handle "no such object" response from Yunex RSUs. Updated command response on GNSS output string to correctly recognize a good NEMA response string. 