### PR TITLE
update regex for rsuGnssOutputString success check

### DIFF
--- a/sample_read_snmp.json
+++ b/sample_read_snmp.json
@@ -51,7 +51,7 @@
                 "snmp_cmd_elements": [
                     "NTCIP1218-v01::rsuGnssOutputString.0"
                 ],
-                "success_return": ["$GPGGA,[0-9]+"],
+                "success_return": ["GPGGA,[0-9]+"],
                 "fail_return": ["error", "GPGGA,{4}"]
             }
         },


### PR DESCRIPTION
really minor fix - removed a space in the regex to recognize the gps string correctly